### PR TITLE
Update shiny-server.service

### DIFF
--- a/config/systemd/shiny-server.service
+++ b/config/systemd/shiny-server.service
@@ -3,7 +3,7 @@ Description=ShinyServer
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/env bash -c 'exec /opt/shiny-server/bin/shiny-server >> /var/log/shiny-server.log 2>&1'
+ExecStart=/usr/bin/env bash -c 'exec /etc/bin/shiny-server >> /var/log/shiny-server.log 2>&1'
 KillMode=process
 ExecReload=/usr/bin/env kill -HUP $MAINPID
 ExecStopPost=/usr/bin/env sleep 5


### PR DESCRIPTION
According to https://github.com/rstudio/shiny-server/wiki/Building-Shiny-Server-from-Source , the executable file is located at /usr/local/shiny-server/bin/shiny-server and we made a link to /usr/bin/shiny-server. This is why, I think the service should execute /usr/bin/shiny-server instead of /opt/shiny-server/bin/shiny-server